### PR TITLE
Increase doc heading color contrast

### DIFF
--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -33,7 +33,7 @@ generate_user_docu() {
 modify_user_docu() {
   for file in ${DOC_DIR}/user/*.html; do
     local title="$(extract_title ${file})"
-    local body="$(echo "$(extract_body ${file})" | sed -e 's/color="purple"/color="#54A23D"/Ig')"
+    local body="$(echo "$(extract_body ${file})" | sed -e 's/color="purple"/color="#3A6F2B"/Ig')"
     generate_report "${title}" "${body}" "${file}"
   done
 }


### PR DESCRIPTION
The doc heading color contrast is only 2.4, where the ADA recommends at
least 4.5. See https://web.dev/color-contrast/.

Darken the color until the color contrast passes validation.

## Current
<img width="583" alt="current" src="https://user-images.githubusercontent.com/637174/171443775-0751aed7-a2fe-48f4-ae6d-b8ab379778ac.png">

## Proposed

### Comparison
<img width="632" alt="new" src="https://user-images.githubusercontent.com/637174/171443972-594c1a99-3123-48a7-a4f8-30525e25890b.png">

### ADA info
<img width="638" alt="new-info" src="https://user-images.githubusercontent.com/637174/171444037-a3abc0d0-1885-4e4a-8431-802ed3d127bc.png">

