### PR TITLE
Add meta description tag

### DIFF
--- a/templates/report-header.sh.html
+++ b/templates/report-header.sh.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta name="description" content="vim out of the box">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <title>${report_title}</title>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">


### PR DESCRIPTION
Add a meta description tag with the same content as the root neovim.io
site.