### PR TITLE
user-docu: generate HTML docs using treesitter

### DIFF
--- a/.github/workflows/reports.yaml
+++ b/.github/workflows/reports.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - 'main'
+  pull_request:
+    branches:
+      - 'main'
   schedule:
     - cron: '5 5 * * *'
   workflow_dispatch:
@@ -108,6 +111,7 @@ jobs:
           git commit -m 'doxygen: Automatic update'
 
       - name: Push update
+        if: (github.event_name != 'pull_request')
         run: |
           cd "$DOC_DIR"
           ${GITHUB_WORKSPACE}/ci/truncate-history.sh

--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -17,12 +17,20 @@ generate_user_docu() {
   # Build user manual HTML
   cd build
   echo "CWD: $(pwd)"
+
+  # Legacy HTML (will be removed)
   ${MAKE_CMD} doc_html
 
   # Copy to doc repository
   rm -rf ${DOC_DIR}/user
   mkdir -p ${DOC_DIR}/user
   cp runtime/doc/*.html ${DOC_DIR}/user
+
+  # Generate HTML from :help docs.
+  (
+    cd ..
+    VIMRUNTIME=runtime/ ./build/bin/nvim -V1 -es --clean +"lua require('scripts.gen_help_html').gen('./build/runtime/doc/', '${DOC_DIR}/user2', nil)" +0cq
+  )
 
   # Modify HTML to match Neovim's layout
   modify_user_docu


### PR DESCRIPTION
## Problem:
The HTML :help docs generated by the old `doc_html` task (which is driven by an old awk script `runtime/doc/makehtml.awk`). Besides being hard to maintain (ad hoc parser and no one has touched it in decades), it has bugs like:

- https://github.com/neovim/neovim.github.io/issues/96
- https://github.com/neovim/neovim.github.io/issues/97

## Solution:

Use the `gen_help_html.lua` script from https://github.com/neovim/neovim/pull/11967

There are some regressions, so currently this generates to a new temporary `user2/` path so that people can try it out.