### PR TITLE
user-docu: generate docs using treesitter

### DIFF
--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -29,7 +29,8 @@ generate_user_docu() {
   # Generate HTML from :help docs.
   (
     cd ..
-    VIMRUNTIME=runtime/ ./build/bin/nvim -V1 -es --clean +"lua require('scripts.gen_help_html').gen('./build/runtime/doc/', '${DOC_DIR}/user2', nil)" +0cq
+    VIMRUNTIME=runtime/ ./build/bin/nvim -V1 -es --clean \
+      +"lua require('scripts.gen_help_html').gen('./build/runtime/doc/', '${DOC_DIR}/user2', nil, '${NEOVIM_COMMIT}')" +0cq
   )
 
   # Modify HTML to match Neovim's layout


### PR DESCRIPTION
Problem:
The HTML :help docs generated by the new `gen_help_html.lua` do not mention the source commit-id in the footer.

Solution:
Since https://github.com/neovim/neovim/pull/20352 the script now accepts a commit-id, so pass it.