### PR TITLE
try_truncate_history: increase from 10 => 100

### DIFF
--- a/ci/common/doc.sh
+++ b/ci/common/doc.sh
@@ -11,8 +11,8 @@ DOC_BRANCH=${DOC_BRANCH:-gh-pages}
 try_truncate_history() {
   cd "${DOC_DIR}" || { log_error "try_truncate_history: cd failed"; exit 1; }
   local branch=gh-pages
-  if NEW_ROOT=$(2>/dev/null git rev-parse "$branch"~11) ; then
-    git_truncate "$branch" "$branch"~10
+  if NEW_ROOT=$(2>/dev/null git rev-parse "$branch"~101) ; then
+    git_truncate "$branch" "$branch"~100
   else
     log_info "try_truncate_history: branch ${branch} has too few commits, skipping truncate"
   fi


### PR DESCRIPTION
The generated files are not as noisy as they used to be, so we can relax truncation. History is useful for comparing recent changes.