### PR TITLE
Removed repetitive "by default" in lua-guide.html

### DIFF
--- a/user/lua-guide.html
+++ b/user/lua-guide.html
@@ -414,7 +414,7 @@ end, { expr = true })</code></pre>
   for mappings they create.<pre><code class="language-lua">vim.keymap.set('n', '&lt;Leader&gt;pl1', require('plugin').action,
   { desc = 'Execute action from plugin' })</code></pre>
 </div></div>
-<div class="old-help-para"><div class="help-li" style=""> <code>remap</code>: By default, all mappings are nonrecursive by default (i.e.,
+<div class="old-help-para"><div class="help-li" style=""> <code>remap</code>: By default, all mappings are nonrecursive (i.e.,
   <a href="lua.html#vim.keymap.set()">vim.keymap.set()</a> behaves like <a href="map.html#%3Anoremap">:noremap</a>). If the <code>{rhs}</code> is itself a mapping
   that should be executed, set <code>remap = true</code>:<pre><code class="language-lua">vim.keymap.set('n', '&lt;Leader&gt;ex1', '&lt;cmd&gt;echo "Example 1"&lt;cr&gt;')
 -- add a shorter mapping


### PR DESCRIPTION
https://neovim.io/doc/user/lua-guide.html:

> - remap: By default, all mappings are nonrecursive by default (i.e., [vim.keymap.set()](https://neovim.io/doc/user/lua.html#vim.keymap.set()) behaves like [:noremap](https://neovim.io/doc/user/map.html#%3Anoremap)). If the {rhs} is itself a mapping that should be executed, set remap = true: