### PR TITLE
docs: how to build user docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repo contains automation scripts and CI configuration to run the scripts.
 To run the scripts locally, execute `./ci/<build script>`, where `build script`
 is any executable shell script. Override environment variables as necessary.
 
+### Example: Build user documentations:
+
+    NEOVIM_DIR=~/neovim-src/ ./ci/user-docu.sh
+
 ### Example: Generate the vim-patch report:
 
     VIM_SOURCE_DIR=~/vim-src/ NEOVIM_DIR=~/neovim-src/ ./ci/vimpatch-report.sh

--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -6,6 +6,7 @@ source ${BUILD_DIR}/ci/common/common.sh
 
 generate_user_docu() {
   require_environment_variable BUILD_DIR "${BASH_SOURCE[0]}" ${LINENO}
+  require_environment_variable NEOVIM_DIR "${BASH_SOURCE[0]}" ${LINENO}
 
   cd ${NEOVIM_DIR}
   make


### PR DESCRIPTION
Problem:

  It is not crystal clear how to run user documentation HTML files
  locally right after checking out this repository.

Solution:

- Add more examples on how to run the user-docu.sh script locally.

- Show error messages if a mandatory variable (`NEOVIM_DIR`) is not set.
  Without `$NEOVIM_DIR`, the script will fail anyway because it would
  behave like running `make` after cd-ing to `$HOME`.
