### PR TITLE
fix: path to gen_help_html script

### DIFF
--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -13,7 +13,7 @@ generate_user_docu() {
 
   # Generate HTML from :help docs.
   VIMRUNTIME=runtime/ ./build/bin/nvim -V1 -es --clean \
-    +"lua require('scripts.gen_help_html').gen('./build/runtime/doc/', '${DOC_DIR}/user', nil, '${NEOVIM_COMMIT}')" +0cq
+    +"lua require('src.gen.gen_help_html').gen('./build/runtime/doc/', '${DOC_DIR}/user', nil, '${NEOVIM_COMMIT}')" +0cq
 }
 
 DOC_SUBTREE="/user/"


### PR DESCRIPTION
Upstream moved the gen scripts from scripts/ to src/gen/